### PR TITLE
corrected includes for newer Guile version

### DIFF
--- a/mk-guile.scm
+++ b/mk-guile.scm
@@ -18,8 +18,8 @@
 (define fxsra fxarithmetic-shift-right)
 (define fxsll bitwise-arithmetic-shift-left)
 
-(include "mk-vicare.scm")
-(include "mk.scm")
+(include-from-path "faster-miniKanren/mk-vicare.scm")
+(include-from-path "faster-miniKanren/mk.scm")
 
 (define (andmap proc . args)
   (let ((l (length (car args))))
@@ -38,4 +38,4 @@
 
 (define generate-temporary gensym)
 
-(include "matche.scm")
+(include-from-path "faster-miniKanren/matche.scm")


### PR DESCRIPTION
* append `faster-miniKanren` to include paths
* changed `include` to `include-from-path`
* `guile test-guile.scm` runs through with no errors on my machine
* `(use-modules (faster-miniKanren mk-guile))` works now for me