### PR TITLE
Provide succeed and fail.

### DIFF
--- a/chez.scm
+++ b/chez.scm
@@ -1,6 +1,6 @@
 (eval-when (compile) (optimize-level 3))
 
-(module mk (run run* defrel == =/= fresh conde symbolo numbero stringo absento test)
+(module mk (run run* defrel == =/= fresh conde symbolo numbero stringo absento succeed fail test)
   (import (except scheme subst))
   (implicit-exports #t)
   (include "./mk-vicare.scm")

--- a/mk-guile.scm
+++ b/mk-guile.scm
@@ -5,6 +5,7 @@
             conde
             symbolo numbero stringo
             absento
+            succeed fail
             matche))
 
 (import (rnrs (6)))

--- a/mk.rkt
+++ b/mk.rkt
@@ -11,8 +11,9 @@
          var?
          always-wrap-reified?)
 
-(require "private-unstable.rkt"
-         (prefix-in mk: "private-unstable.rkt"))
+(require (rename-in "private-unstable.rkt"
+                    [fail mk:fail]
+                    [succeed mk:succeed]))
 
 (define fail (procedure-rename mk:fail 'fail))
 (define succeed (procedure-rename mk:succeed 'succeed))

--- a/mk.rkt
+++ b/mk.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (provide run run* defrel
+         fail succeed
          == =/=
          fresh
          conde
@@ -10,4 +11,8 @@
          var?
          always-wrap-reified?)
 
-(require "private-unstable.rkt")
+(require "private-unstable.rkt"
+         (prefix-in mk: "private-unstable.rkt"))
+
+(define fail (procedure-rename mk:fail 'fail))
+(define succeed (procedure-rename mk:succeed 'succeed))

--- a/mk.rkt
+++ b/mk.rkt
@@ -11,9 +11,4 @@
          var?
          always-wrap-reified?)
 
-(require (rename-in "private-unstable.rkt"
-                    [fail mk:fail]
-                    [succeed mk:succeed]))
-
-(define fail (procedure-rename mk:fail 'fail))
-(define succeed (procedure-rename mk:succeed 'succeed))
+(require "private-unstable.rkt")

--- a/mk.scm
+++ b/mk.scm
@@ -537,8 +537,8 @@
        (let ((x (walk* x (state-S st))) ...)
          ((fresh () g g* ...) st))))))
 
-(define succeed (== #f #f))
-(define fail (== #f #t))
+(define (succeed st) st)
+(define (fail st) #f)
 
 
 ; Reification


### PR DESCRIPTION
`succeed` and `fail` are used in The Reasoned Schemer, it seems reasonable to provide them. The book also uses the reader syntax `#s` and `#u`, which might be interesting to provide but that would require a reader extension and probably a `#lang`. That doesn't seem worth the effort at the moment.