### PR TITLE
Ensure `vars` produces list w/o dups, even on var-var pair. Test.

### DIFF
--- a/mk.scm
+++ b/mk.scm
@@ -563,12 +563,13 @@
               (walk* A R))))))
 
 (define (vars term)
-  (let rec ((term term) (acc '()))
-    (cond
-      ((var? term) (cons term acc))
-      ((pair? term)
-       (rec (cdr term) (rec (car term) acc)))
-      (else (remove-duplicates acc)))))
+  (remove-duplicates
+	(let rec ((term term) (acc '()))
+	  (cond
+		((var? term) (cons term acc))
+		((pair? term)
+		 (rec (cdr term) (rec (car term) acc)))
+		(else acc)))))
 
 (define (extract-and-normalize st relevant-vars x)
   (define T (map (lambda (tc-type)

--- a/symbolo-tests.scm
+++ b/symbolo-tests.scm
@@ -279,3 +279,7 @@
       (=/= `(,w ,y) `(,x ,z))
       (== `(,w ,x ,y ,z) q)))
   '(((a a _.0 _.1) (=/= ((_.0 _.1))))))
+
+(test "test reifier tags each var only once"
+  (run 1 (q) (fresh (x y) (== q (cons x (cons x y))) (symbolo x)))
+  '(((_.0 _.0 . _.1) (sym _.0))))


### PR DESCRIPTION
Fixes https://github.com/michaelballantyne/faster-minikanren/issues/21.